### PR TITLE
Fix for the double click selection issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ After the user is returned from the queue, the Worker script will let the user c
 
 8. On the Worker setup page, select the toggle switch on "Deployed to `queue-itconnector.yoursite.workers.dev`" to deploy the Worker to production
 
-9. Select the "Settings" tab -> KV Namespace Bindings -> "Add variable". For "Variable name" enter `IntegrationConfigKV` and for "KV namespace" select `IntegrationConfigKV` which you had added before -> Save
+9. Select the "Settings" tab -> KV Namespace Bindings -> "Add variable". For "Variable name" enter "`IntegrationConfigKV`" and for "KV namespace" select "`IntegrationConfigKV`" which you had added before -> Save
 
 10. Navigate back to the Cloudflare Dashboard and select "Workers" -> "Add route"
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ After the user is returned from the queue, the Worker script will let the user c
 
 8. On the Worker setup page, select the toggle switch on "Deployed to `queue-itconnector.yoursite.workers.dev`" to deploy the Worker to production
 
-9. Select the "Settings" tab -> KV Namespace Bindings -> "Add variable". For "Variable name" enter "`IntegrationConfigKV`" and for "KV namespace" select "`IntegrationConfigKV`" which you had added before -> Save
+9. On the "Settings" tab, under the "KV Namespace Bindings" heading, click the "Add variable" button. For "Variable name" enter "`IntegrationConfigKV`" and for "KV namespace" select "`IntegrationConfigKV`" from the dropdown which you had added before in Step 1. Click "Save".
 
 10. Navigate back to the Cloudflare Dashboard and select "Workers" -> "Add route"
 


### PR DESCRIPTION
By surrounding the variable names with `"` (double quotes) prevents the selection of an extra white space after the clicked word.